### PR TITLE
feat: 同步 OpenClaw v2026.1.24 命令变更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # ============================================================
-# ClawdBot Docker 镜像
-# 
-# 构建: docker build -t clawdbot .
-# 运行: docker run -d --name clawdbot -v ~/.clawdbot:/root/.clawdbot clawdbot
+# OpenClaw Docker 镜像
+#
+# 构建: docker build -t openclaw .
+# 运行: docker run -d --name openclaw -v ~/.openclaw:/root/.openclaw openclaw
 # ============================================================
 
 FROM node:22-alpine
 
-LABEL maintainer="ClawdBot Community"
-LABEL description="ClawdBot - Your Personal AI Assistant"
+LABEL maintainer="OpenClaw Community"
+LABEL description="OpenClaw - Your Personal AI Assistant"
 LABEL version="1.0.0"
 
 # 安装基础依赖
@@ -26,32 +26,32 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # 创建工作目录
 WORKDIR /app
 
-# 安装 ClawdBot
-RUN npm install -g clawdbot@latest
+# 安装 OpenClaw
+RUN npm install -g openclaw@latest
 
 # 创建配置目录
-RUN mkdir -p /root/.clawdbot/logs \
-    /root/.clawdbot/data \
-    /root/.clawdbot/skills \
-    /root/.clawdbot/backups
+RUN mkdir -p /root/.openclaw/logs \
+    /root/.openclaw/data \
+    /root/.openclaw/skills \
+    /root/.openclaw/backups
 
 # 复制默认配置和技能
-COPY examples/config.example.yaml /root/.clawdbot/config.yaml.example
-COPY examples/skills/ /root/.clawdbot/skills/
+COPY examples/config.example.yaml /root/.openclaw/config.yaml.example
+COPY examples/skills/ /root/.openclaw/skills/
 
 # 设置卷挂载点
-VOLUME ["/root/.clawdbot"]
+VOLUME ["/root/.openclaw"]
 
 # 暴露端口
 EXPOSE 18789
 
 # 健康检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD clawdbot health || exit 1
+    CMD openclaw health || exit 1
 
 # 入口脚本
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["clawdbot", "start", "--daemon"]
+CMD ["openclaw", "gateway"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🦞 ClawdBot 一键部署工具
+# 🦞 OpenClaw 一键部署工具
 
 <p align="center">
   <img src="https://img.shields.io/badge/Version-1.0.0-blue.svg" alt="Version">
@@ -6,10 +6,10 @@
   <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License">
 </p>
 
-> 🚀 一键部署你的私人 AI 助手 ClawdBot，支持多平台多模型配置
+> 🚀 一键部署你的私人 AI 助手 OpenClaw，支持多平台多模型配置
 
 <p align="center">
-  <img src="photo/menu.png" alt="ClawdBot 配置中心" width="600">
+  <img src="photo/menu.png" alt="OpenClaw 配置中心" width="600">
 </p>
 
 ## 📖 目录
@@ -29,7 +29,7 @@
 ### 🤖 多模型支持
 
 <p align="center">
-  <img src="photo/llm.png" alt="AI 模型配置" width="600">
+  <img src="photo/llm.png" alt="OpenClaw AI 模型配置" width="600">
 </p>
 
 **主流服务商:**
@@ -60,10 +60,12 @@
 
 > 💡 **自定义 API 地址**: Anthropic Claude 和 OpenAI GPT 都支持自定义 API 地址，可接入 OneAPI/NewAPI/API 代理等服务。配置时先输入自定义地址，再输入 API Key。
 
+> ⚠️ **重要更新**: 从 v2026.1.9 版本开始，命令已从 `clawdbot` 更改为 `openclaw`，`message` 命令改为子命令格式。
+
 ### 📱 多渠道接入
 
 <p align="center">
-  <img src="photo/social.png" alt="消息渠道配置" width="600">
+  <img src="photo/social.png" alt="OpenClaw 消息渠道配置" width="600">
 </p>
 
 - Telegram Bot
@@ -77,12 +79,12 @@
 ### 🧪 快速测试
 
 <p align="center">
-  <img src="photo/messages.png" alt="快速测试" width="600">
+  <img src="photo/messages.png" alt="OpenClaw 快速测试" width="600">
 </p>
 
 - API 连接测试
 - 渠道连接验证
-- ClawdBot 诊断工具
+- OpenClaw 诊断工具
 
 ### 🧠 核心能力
 - **持久记忆** - 跨对话、跨平台的长期记忆
@@ -105,23 +107,23 @@
 
 ```bash
 # 下载并运行安装脚本
-curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/miaoxworld/OpenClawInstaller/main/install.sh | bash
 ```
 
 安装脚本会自动：
 1. 检测系统环境并安装依赖
-2. 安装 ClawdBot
+2. 安装 OpenClaw
 3. 引导完成核心配置（AI模型、身份信息）
 4. 测试 API 连接
-5. **自动启动 ClawdBot 服务**
+5. **自动启动 OpenClaw 服务**
 6. 可选打开配置菜单进行详细配置（渠道等）
 
 ### 方式二：手动安装
 
 ```bash
 # 1. 克隆仓库
-git clone https://github.com/miaoxworld/ClawdBotInstaller.git
-cd ClawdBotInstaller
+git clone https://github.com/miaoxworld/OpenClawInstaller.git
+cd OpenClawInstaller
 
 # 2. 添加执行权限
 chmod +x install.sh config-menu.sh
@@ -134,23 +136,23 @@ chmod +x install.sh config-menu.sh
 
 安装完成后脚本会：
 1. **自动询问是否启动服务**（推荐选择 Y）
-2. 后台启动 ClawdBot Gateway
+2. 后台启动 OpenClaw Gateway
 3. 可选打开配置菜单进行渠道配置
 
 如果需要后续管理：
 
 ```bash
 # 手动启动服务
-source ~/.clawdbot/env && clawdbot gateway
+source ~/.openclaw/env && openclaw gateway
 
 # 后台启动服务
-clawdbot gateway start
+openclaw gateway start
 
 # 运行配置菜单进行详细配置
-bash ~/.clawdbot/config-menu.sh
+bash ~/.openclaw/config-menu.sh
 
 # 或从 GitHub 下载运行
-curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/config-menu.sh | bash
+curl -fsSL https://raw.githubusercontent.com/miaoxworld/OpenClawInstaller/main/config-menu.sh | bash
 ```
 
 ## ⚙️ 详细配置
@@ -160,7 +162,7 @@ curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/c
 运行配置菜单后选择 `[2] AI 模型配置`，可选择多种 AI 提供商：
 
 <p align="center">
-  <img src="photo/llm.png" alt="AI 模型配置界面" width="600">
+  <img src="photo/llm.png" alt="OpenClaw AI 模型配置界面" width="600">
 </p>
 
 #### Anthropic Claude 配置
@@ -168,7 +170,7 @@ curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/c
 1. 在配置菜单中选择 Anthropic Claude
 2. **先输入自定义 API 地址**（留空使用官方 API）
 3. 输入 API Key（官方 Key 从 [Anthropic Console](https://console.anthropic.com/) 获取）
-4. 选择模型（推荐 Sonnet 4）
+4. 选择模型（推荐 Sonnet 4.5）
 
 > 💡 支持 OneAPI/NewAPI 等第三方代理服务，只需填入对应的 API 地址和 Key
 
@@ -177,7 +179,7 @@ curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/c
 1. 在配置菜单中选择 OpenAI GPT
 2. **先输入自定义 API 地址**（留空使用官方 API）
 3. 输入 API Key（官方 Key 从 [OpenAI Platform](https://platform.openai.com/) 获取）
-4. 选择模型
+4. 选择模型（推荐 GPT-4o）
 
 #### Ollama 本地模型
 
@@ -186,7 +188,7 @@ curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/c
 curl -fsSL https://ollama.ai/install.sh | sh
 
 # 2. 下载模型
-ollama pull llama3
+ollama pull llama3.3
 
 # 3. 在配置菜单中选择 Ollama
 # 输入服务地址：http://localhost:11434
@@ -197,14 +199,14 @@ ollama pull llama3
 1. 访问 [Groq Console](https://console.groq.com/) 获取 API Key
 2. 在配置菜单中选择 Groq
 3. 输入 API Key
-4. 选择模型（推荐 llama-3.3-70b-versatile）
+4. 选择模型（推荐 llama-3.3-70b-versatile 或 llama-4）
 
 #### Google Gemini
 
-1. 访问 [Google AI Studio](https://makersuite.google.com/app/apikey) 获取 API Key
+1. 访问 [Google AI Studio](https://aistudio.google.com/app/apikey) 获取 API Key
 2. 在配置菜单中选择 Google Gemini
 3. 输入 API Key
-4. 选择模型（推荐 gemini-2.0-flash）
+4. 选择模型（推荐 gemini-2.0-flash 或 gemini-2.5-pro）
 
 ### 配置 Telegram 机器人
 
@@ -247,72 +249,102 @@ ollama pull llama3
 
 ```bash
 # 启动服务（后台守护进程）
-clawdbot gateway start
+openclaw gateway start
 
 # 停止服务
-clawdbot gateway stop
+openclaw gateway stop
 
-# 重启服务
-clawdbot gateway restart
+# 查看服务状态（表格格式，包含 OS/update/gateway/daemon/agents/sessions）
+openclaw status
 
-# 查看服务状态
-clawdbot gateway status
+# 查看完整状态报告
+openclaw status --all
 
 # 前台运行（用于调试）
-clawdbot gateway
+openclaw gateway --port 18789 --verbose
 
 # 查看日志
-clawdbot logs
+openclaw logs
 
 # 实时日志
-clawdbot logs --follow
+openclaw logs --follow
 ```
 
 ### 配置管理
 
 ```bash
 # 打开配置文件
-clawdbot config
+openclaw config
 
 # 运行配置向导
-clawdbot onboard
+openclaw onboard --install-daemon
 
 # 诊断配置问题
-clawdbot doctor
+openclaw doctor
 
 # 健康检查
-clawdbot health
+openclaw health
+```
+
+### 消息发送（v2026.1.9+ 新格式）
+
+```bash
+# 发送消息（必须指定 provider，除非只配置了一个）
+openclaw message send --to +1234567890 --message "Hello" --provider <provider>
+
+# 轮询消息
+openclaw message poll --provider <provider>
+```
+
+### Agent 交互
+
+```bash
+# 与助手对话
+openclaw agent --message "Ship checklist" --thinking high
+
+# 本地测试
+openclaw agent --local --to "+1234567890" --message "Test message"
+```
+
+### 更新命令（v2026.1.10+ 新增）
+
+```bash
+# 更新到最新版本
+openclaw update
+
+# 或简写形式
+openclaw --update
 ```
 
 ### 数据管理
 
 ```bash
 # 导出对话历史
-clawdbot export --format json
+openclaw export --format json
 
 # 清理记忆
-clawdbot memory clear
+openclaw memory clear
 
 # 备份数据
-clawdbot backup
+openclaw backup
 ```
 
 ## 📋 配置说明
 
-ClawdBot 使用以下配置方式：
+OpenClaw 使用以下配置方式：
 
-- **环境变量**: `~/.clawdbot/env` - 存储 API Key 和 Base URL
-- **ClawdBot 配置**: `~/.clawdbot/clawdbot.json` - ClawdBot 内部配置（自动管理）
-- **命令行工具**: `clawdbot config set` / `clawdbot models set` 等
+- **环境变量**: `~/.openclaw/env` - 存储 API Key 和 Base URL
+- **OpenClaw 配置**: `~/.openclaw/openclaw.json` - OpenClaw 内部配置（自动管理）
+- **命令行工具**: `openclaw config set` / `openclaw models set` 等
 
 > 💡 **注意**：配置主要通过安装向导或 `config-menu.sh` 完成，无需手动编辑配置文件
 
 ### 环境变量配置示例
 
-`~/.clawdbot/env` 文件内容：
+`~/.openclaw/env` 文件内容：
 
 ```bash
-# ClawdBot 环境变量配置
+# OpenClaw 环境变量配置
 export ANTHROPIC_API_KEY=sk-ant-xxxxx
 export ANTHROPIC_BASE_URL=https://your-api-proxy.com  # 可选，自定义 API 地址
 
@@ -323,7 +355,7 @@ export OPENAI_BASE_URL=https://your-api-proxy.com/v1  # 可选
 
 ### 自定义 Provider 配置
 
-当使用自定义 API 地址时，安装脚本会自动在 `~/.clawdbot/clawdbot.json` 中配置自定义 Provider：
+当使用自定义 API 地址时，安装脚本会自动在 `~/.openclaw/openclaw.json` 中配置自定义 Provider：
 
 ```json
 {
@@ -351,44 +383,59 @@ export OPENAI_BASE_URL=https://your-api-proxy.com/v1  # 可选
 ### 目录结构
 
 ```
-~/.clawdbot/
-├── clawdbot.json        # ClawdBot 核心配置
+~/.openclaw/
+├── openclaw.json        # OpenClaw 核心配置
 ├── env                  # 环境变量 (API Key 等)
 ├── backups/             # 配置备份
-└── logs/                # 日志文件 (由 ClawdBot 管理)
+└── logs/                # 日志文件 (由 OpenClaw 管理)
 ```
 
 ## 🛡️ 安全建议
 
-> ⚠️ **重要警告**：ClawdBot 需要完全的计算机权限，请务必注意安全！
+> ⚠️ **重要警告**：OpenClaw 需要完全的计算机权限，请务必注意安全！
 
 ### 部署建议
 
 1. **不要在主工作电脑上部署** - 建议使用专用服务器或虚拟机
 2. **使用 AWS/GCP/Azure 免费实例** - 隔离环境更安全
 3. **Docker 部署** - 提供额外的隔离层
+4. **沙箱模式** - 设置 `agents.defaults.sandbox.mode: "non-main"` 运行非主会话在 Docker 沙箱中
 
 ### 权限控制
 
 1. **禁用危险功能**（默认已禁用）
-   ```yaml
-   security:
-     enable_shell_commands: false
-     enable_file_access: false
+   ```json
+   {
+     "security": {
+       "enable_shell_commands": false,
+       "enable_file_access": false
+     }
+   }
    ```
 
-2. **启用沙箱模式**
-   ```yaml
-   security:
-     sandbox_mode: true
+2. **启用沙箱模式**（推荐用于非主会话）
+   ```json
+   {
+     "agents": {
+       "defaults": {
+         "sandbox": {
+           "mode": "non-main"
+         }
+       }
+     }
+   }
    ```
 
-3. **限制允许的用户**
-   ```yaml
-   channels:
-     telegram:
-       allowed_users:
-         - "only-your-user-id"
+3. **DM 配对策略**（防止未知用户访问）
+   ```json
+   {
+     "channels": {
+       "telegram": {
+         "dmPolicy": "pairing",
+         "allowFrom": ["your-user-id"]
+       }
+     }
+   }
    ```
 
 ### API Key 安全
@@ -396,6 +443,7 @@ export OPENAI_BASE_URL=https://your-api-proxy.com/v1  # 可选
 - 定期轮换 API Key
 - 不要在公开仓库中提交配置文件
 - 使用环境变量存储敏感信息
+- 使用 `openclaw doctor` 检查配置安全性
 
 ```bash
 # 使用环境变量
@@ -406,6 +454,8 @@ export TELEGRAM_BOT_TOKEN="xxx"
 ## ❓ 常见问题
 
 ### Q: 安装时提示 Node.js 版本过低？
+
+OpenClaw 需要 Node.js v22 或更高版本。
 
 ```bash
 # macOS
@@ -419,51 +469,69 @@ sudo apt-get install -y nodejs
 
 ### Q: 启动后无法连接？
 
-1. 检查配置文件是否正确
-2. 运行诊断命令：`clawdbot doctor`
-3. 查看日志：`clawdbot logs`
+1. 检查配置文件是否正确 (`~/.openclaw/openclaw.json`)
+2. 运行诊断命令：`openclaw doctor`
+3. 查看日志：`openclaw logs`
+4. 检查健康状态：`openclaw health`
 
 ### Q: Telegram 机器人没有响应？
 
 1. 确认 Bot Token 正确
-2. 确认 User ID 在 allowed_users 列表中
-3. 检查网络连接（可能需要代理）
+2. 确认 User ID 在 `allowFrom` 列表中
+3. 检查 DM 配对策略设置
+4. 检查网络连接（可能需要代理）
+5. 运行 `openclaw channels list` 查看渠道状态
 
 ### Q: 如何更新到最新版本？
 
 ```bash
-# 使用 npm 更新
-npm update -g clawdbot
+# 方法 1: 使用 openclaw update 命令 (v2026.1.10+)
+openclaw update
 
-# 或使用配置菜单
+# 或简写
+openclaw --update
+
+# 方法 2: 使用 npm 更新
+npm update -g openclaw
+
+# 方法 3: 使用配置菜单
 ./config-menu.sh
-# 选择 [7] 高级设置 → [7] 更新 ClawdBot
+# 选择 [7] 高级设置 → [7] 更新 OpenClaw
 ```
 
 ### Q: 如何备份数据？
 
 ```bash
 # 手动备份
-cp -r ~/.clawdbot ~/clawdbot_backup_$(date +%Y%m%d)
+cp -r ~/.openclaw ~/openclaw_backup_$(date +%Y%m%d)
 
 # 使用命令备份
-clawdbot backup
+openclaw backup
 ```
 
 ### Q: 如何完全卸载？
 
 ```bash
 # 停止服务
-clawdbot gateway stop
+openclaw gateway stop
 
 # 卸载程序
-npm uninstall -g clawdbot
+npm uninstall -g openclaw
 
 # 删除配置（可选）
-rm -rf ~/.clawdbot
+rm -rf ~/.openclaw
 ```
 
 ## 📜 更新日志
+
+### v1.1.0 (2026-01-30)
+- 🔄 同步 OpenClaw v2026.1.24 命令变更
+- 📝 命令从 `clawdbot` 更改为 `openclaw`
+- ⚠️ `message` 命令改为子命令格式 `message send|poll|...`
+- ✨ 新增 `openclaw update` 更新命令
+- ✨ 新增 `openclaw status --all` 完整状态报告
+- 🔒 更新安全配置说明（DM 配对策略）
+- 📚 完善文档和常见问题
 
 ### v1.0.0 (2026-01-29)
 - 🎉 首次发布
@@ -480,11 +548,12 @@ rm -rf ~/.clawdbot
 
 ## 🔗 相关链接
 
-- [ClawdBot 官网](https://clawd.bot)
-- [官方文档](https://clawd.bot/docs)
-- [安装工具仓库](https://github.com/miaoxworld/ClawdBotInstaller)
-- [ClawdBot 主仓库](https://github.com/clawdbot/clawdbot)
-- [社区讨论](https://github.com/miaoxworld/ClawdBotInstaller/discussions)
+- [OpenClaw 官网](https://openclaw.ai)
+- [官方文档](https://docs.openclaw.ai)
+- [安装工具仓库](https://github.com/miaoxworld/OpenClawInstaller)
+- [OpenClaw 主仓库](https://github.com/openclaw/openclaw)
+- [社区 Discord](https://discord.gg/clawd)
+- [社区讨论](https://github.com/miaoxworld/OpenClawInstaller/discussions)
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 # ============================================================
-# ClawdBot Docker Compose 配置
-# 
+# OpenClaw Docker Compose 配置
+#
 # 使用方法:
-#   1. 复制 examples/config.example.yaml 到 ~/.clawdbot/config.yaml
+#   1. 复制 examples/config.example.yaml 到 ~/.openclaw/config.yaml
 #   2. 编辑配置文件，填入你的 API Key
 #   3. 运行: docker-compose up -d
 #   4. 查看日志: docker-compose logs -f
@@ -11,12 +11,12 @@
 version: '3.8'
 
 services:
-  clawdbot:
+  openclaw:
     build: .
-    image: clawdbot:latest
-    container_name: clawdbot
+    image: openclaw:latest
+    container_name: openclaw
     restart: unless-stopped
-    
+
     # 环境变量（可选，优先级高于配置文件）
     environment:
       - TZ=Asia/Shanghai
@@ -24,36 +24,36 @@ services:
       # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       # - OPENAI_API_KEY=${OPENAI_API_KEY}
       # - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
-    
+
     # 端口映射
     ports:
       - "18789:18789"
-    
+
     # 卷挂载
     volumes:
       # 配置和数据持久化
-      - ~/.clawdbot:/root/.clawdbot
+      - ~/.openclaw:/root/.openclaw
       # 可选：挂载自定义技能目录
-      # - ./custom-skills:/root/.clawdbot/skills
-    
+      # - ./custom-skills:/root/.openclaw/skills
+
     # 健康检查
     healthcheck:
-      test: ["CMD", "clawdbot", "health"]
+      test: ["CMD", "openclaw", "health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 10s
-    
+
     # 日志配置
     logging:
       driver: "json-file"
       options:
         max-size: "10m"
         max-file: "3"
-    
+
     # 网络配置
     networks:
-      - clawdbot-network
+      - openclaw-network
 
   # 可选：Ollama 本地模型服务
   # 取消注释以启用本地 AI 模型
@@ -66,7 +66,7 @@ services:
   #   volumes:
   #     - ollama-data:/root/.ollama
   #   networks:
-  #     - clawdbot-network
+  #     - openclaw-network
   #   deploy:
   #     resources:
   #       reservations:
@@ -76,7 +76,7 @@ services:
   #             capabilities: [gpu]
 
 networks:
-  clawdbot-network:
+  openclaw-network:
     driver: bridge
 
 # volumes:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CONFIG_DIR="/root/.clawdbot"
+CONFIG_DIR="/root/.openclaw"
 CONFIG_FILE="$CONFIG_DIR/config.yaml"
 
 # 如果配置文件不存在，复制示例配置
@@ -18,7 +18,7 @@ mkdir -p "$CONFIG_DIR/skills"
 
 # 打印启动信息
 echo ""
-echo "🦞 ClawdBot Docker Container"
+echo "🦞 OpenClaw Docker Container"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "配置目录: $CONFIG_DIR"
 echo "日志目录: $CONFIG_DIR/logs"

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1,7 +1,7 @@
 # ============================================================
-# ClawdBot 配置文件示例
-# 复制此文件到 ~/.clawdbot/config.yaml 并修改相关配置
-# 详细文档: https://clawd.bot/docs/config
+# OpenClaw 配置文件示例
+# 复制此文件到 ~/.openclaw/config.yaml 并修改相关配置
+# 详细文档: https://opencode.ai/docs/config
 # ============================================================
 
 # 配置版本
@@ -187,7 +187,7 @@ channels:
   whatsapp:
     enabled: false
     
-    # WhatsApp 使用二维码登录，运行 clawdbot onboard --provider whatsapp
+    # WhatsApp 使用二维码登录，运行 openclaw onboard --provider whatsapp
 
   # ----------------------------------------------------------
   # Slack 配置
@@ -210,14 +210,14 @@ channels:
   # ----------------------------------------------------------
   wechat:
     enabled: false
-    # 微信接入需要额外配置，运行 clawdbot onboard --provider wechat
+    # 微信接入需要额外配置，运行 openclaw onboard --provider wechat
 
   # ----------------------------------------------------------
   # iMessage 配置 (仅 macOS)
   # ----------------------------------------------------------
   imessage:
     enabled: false
-    # 需要完整磁盘访问权限，运行 clawdbot onboard --provider imessage
+    # 需要完整磁盘访问权限，运行 openclaw onboard --provider imessage
 
   # ----------------------------------------------------------
   # 飞书配置 (Feishu/Lark)
@@ -248,7 +248,7 @@ memory:
   enabled: true
   
   # 记忆存储路径
-  storage_path: "~/.clawdbot/data/memory"
+  storage_path: "~/.openclaw/data/memory"
   
   # 最大上下文长度（token）
   max_context_length: 32000
@@ -269,7 +269,7 @@ skills:
   enabled: true
   
   # 技能文件目录
-  path: "~/.clawdbot/skills"
+  path: "~/.openclaw/skills"
   
   # 内置技能开关
   builtin:
@@ -304,7 +304,7 @@ security:
   
   # 文件访问白名单（仅当 enable_file_access 为 true 时生效）
   file_whitelist:
-    - "~/.clawdbot/"
+    - "~/.openclaw/"
     - "~/Documents/"
   
   # 敏感信息过滤
@@ -347,7 +347,7 @@ logging:
   level: "info"
   
   # 日志文件路径
-  path: "~/.clawdbot/logs"
+  path: "~/.openclaw/logs"
   
   # 单个日志文件最大大小
   max_size: "10MB"

--- a/examples/skills/reminder.md
+++ b/examples/skills/reminder.md
@@ -93,7 +93,7 @@ skills:
     max_reminders: 100        # 最大提醒数量
     default_advance: 15       # 默认提前提醒（分钟）
     persist: true             # 重启后保留提醒
-    storage: "~/.clawdbot/data/reminders.json"
+    storage: "~/.openclaw/data/reminders.json"
     channels:
       - telegram
       - discord

--- a/install.sh
+++ b/install.sh
@@ -2,16 +2,22 @@
 #
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║                                                                           ║
-# ║   🦞 ClawdBot 一键部署脚本 v1.0.0                                          ║
+# ║   🦞 OpenClaw 一键部署脚本 v1.1.0                                          ║
 # ║   智能 AI 助手部署工具 - 支持多平台多模型                                    ║
 # ║                                                                           ║
-# ║   GitHub: https://github.com/miaoxworld/ClawdBotInstaller                 ║
-# ║   官方文档: https://clawd.bot/docs                                         ║
-# ║                                                                           ║
+# ║   GitHub: https://github.com/miaoxworld/OpenClawInstaller                 ║
+# ║   官方文档: https://docs.openclaw.ai                                       ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 #
 # 使用方法:
-#   curl -fsSL https://raw.githubusercontent.com/miaoxworld/ClawdBotInstaller/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/miaoxworld/OpenClawInstaller/main/install.sh | bash
+#   或本地执行: chmod +x install.sh && ./install.sh
+#
+# 版本更新:
+#   v1.1.0 - 同步 OpenClaw v2026.1.24 命令变更 (clawdbot -> openclaw)
+#
+# 使用方法:
+#   curl -fsSL https://raw.githubusercontent.com/miaoxworld/OpenClawInstaller/main/install.sh | bash
 #   或本地执行: chmod +x install.sh && ./install.sh
 #
 
@@ -39,10 +45,10 @@ GRAY='\033[0;90m'
 NC='\033[0m' # 无颜色
 
 # ================================ 配置变量 ================================
-CLAWDBOT_VERSION="latest"
-CONFIG_DIR="$HOME/.clawdbot"
+OPENCLAW_VERSION="latest"
+CONFIG_DIR="$HOME/.openclaw"
 MIN_NODE_VERSION=22
-GITHUB_REPO="miaoxworld/ClawdBotInstaller"
+GITHUB_REPO="miaoxworld/OpenClawInstaller"
 GITHUB_RAW_URL="https://raw.githubusercontent.com/$GITHUB_REPO/main"
 
 # ================================ 工具函数 ================================
@@ -51,14 +57,14 @@ print_banner() {
     echo -e "${CYAN}"
     cat << 'EOF'
     
-     ██████╗██╗      █████╗ ██╗    ██╗██████╗ ██████╗  ██████╗ ████████╗
-    ██╔════╝██║     ██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔═══██╗╚══██╔══╝
-    ██║     ██║     ███████║██║ █╗ ██║██║  ██║██████╔╝██║   ██║   ██║   
-    ██║     ██║     ██╔══██║██║███╗██║██║  ██║██╔══██╗██║   ██║   ██║   
-    ╚██████╗███████╗██║  ██║╚███╔███╔╝██████╔╝██████╔╝╚██████╔╝   ██║   
-     ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═════╝ ╚═════╝  ╚═════╝    ╚═╝   
-                                                                         
-              🦞 智能 AI 助手一键部署工具 v1.0.0 🦞
+     ██████╗ ██████╗ ███████╗███╗   ██╗ ██████╗██╗      █████╗ ██╗   ██╗
+    ██╔═══██╗██╔══██╗██╔════╝████╗  ██║██╔════╝██║     ██╔══██╗╚██╗ ██╔╝
+    ██║   ██║██████╔╝█████╗  ██╔██╗ ██║██║     ██║     ███████║ ╚████╔╝ 
+    ██║   ██║██╔══██╗██╔══╝  ██║╚██╗██║██║     ██║     ██╔══██║  ╚██╔╝  
+    ╚██████╔╝██████╔╝███████╗██║ ╚████║╚██████╗███████╗██║  ██║   ██║   
+     ╚═════╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚══════╝╚═╝  ╚═╝   ╚═╝   
+                                                                          
+              🦞 智能 AI 助手一键部署工具 v1.1.0 🦞
     
 EOF
     echo -e "${NC}"
@@ -272,7 +278,7 @@ install_dependencies() {
     install_nodejs
 }
 
-# ================================ ClawdBot 安装 ================================
+# ================================ OpenClaw 安装 ================================
 
 create_directories() {
     log_step "创建配置目录..."
@@ -282,64 +288,64 @@ create_directories() {
     log_info "配置目录: $CONFIG_DIR"
 }
 
-install_clawdbot() {
-    log_step "安装 ClawdBot..."
+install_openclaw() {
+    log_step "安装 OpenClaw..."
     
     # 检查是否已安装
-    if check_command clawdbot; then
-        local current_version=$(clawdbot --version 2>/dev/null || echo "unknown")
-        log_warn "ClawdBot 已安装 (版本: $current_version)"
+    if check_command openclaw; then
+        local current_version=$(openclaw --version 2>/dev/null || echo "unknown")
+        log_warn "OpenClaw 已安装 (版本: $current_version)"
         if ! confirm "是否重新安装/更新？"; then
-            init_clawdbot_config
+            init_openclaw_config
             return 0
         fi
     fi
     
     # 使用 npm 全局安装
-    log_info "正在从 npm 安装 ClawdBot..."
-    npm install -g clawdbot@$CLAWDBOT_VERSION
+    log_info "正在从 npm 安装 OpenClaw..."
+    npm install -g openclaw@$OPENCLAW_VERSION
     
     # 验证安装
-    if check_command clawdbot; then
-        log_info "ClawdBot 安装成功: $(clawdbot --version 2>/dev/null || echo 'installed')"
-        init_clawdbot_config
+    if check_command openclaw; then
+        log_info "OpenClaw 安装成功: $(openclaw --version 2>/dev/null || echo 'installed')"
+        init_openclaw_config
     else
-        log_error "ClawdBot 安装失败"
+        log_error "OpenClaw 安装失败"
         exit 1
     fi
 }
 
-# 初始化 ClawdBot 配置
-init_clawdbot_config() {
-    log_step "初始化 ClawdBot 配置..."
+# 初始化 OpenClaw 配置
+init_openclaw_config() {
+    log_step "初始化 OpenClaw 配置..."
     
-    local CLAWDBOT_DIR="$HOME/.clawdbot"
+    local OPENCLAW_DIR="$HOME/.openclaw"
     
     # 创建必要的目录
-    mkdir -p "$CLAWDBOT_DIR/agents/main/sessions"
-    mkdir -p "$CLAWDBOT_DIR/agents/main/agent"
-    mkdir -p "$CLAWDBOT_DIR/credentials"
+    mkdir -p "$OPENCLAW_DIR/agents/main/sessions"
+    mkdir -p "$OPENCLAW_DIR/agents/main/agent"
+    mkdir -p "$OPENCLAW_DIR/credentials"
     
     # 修复权限
-    chmod 700 "$CLAWDBOT_DIR" 2>/dev/null || true
+    chmod 700 "$OPENCLAW_DIR" 2>/dev/null || true
     
     # 设置 gateway.mode 为 local
-    if check_command clawdbot; then
-        clawdbot config set gateway.mode local 2>/dev/null || true
+    if check_command openclaw; then
+        openclaw config set gateway.mode local 2>/dev/null || true
         log_info "Gateway 模式已设置为 local"
     fi
 }
 
-# 配置 ClawdBot 使用的 AI 模型和 API Key
-configure_clawdbot_model() {
-    log_step "配置 ClawdBot AI 模型..."
+# 配置 OpenClaw 使用的 AI 模型和 API Key
+configure_openclaw_model() {
+    log_step "配置 OpenClaw AI 模型..."
     
-    local env_file="$HOME/.clawdbot/env"
-    local clawdbot_json="$HOME/.clawdbot/clawdbot.json"
+    local env_file="$HOME/.openclaw/env"
+    local openclaw_json="$HOME/.openclaw/openclaw.json"
     
     # 创建环境变量文件
     cat > "$env_file" << EOF
-# ClawdBot 环境变量配置
+# OpenClaw 环境变量配置
 # 由安装脚本自动生成: $(date '+%Y-%m-%d %H:%M:%S')
 EOF
 
@@ -378,58 +384,58 @@ EOF
     log_info "环境变量配置已保存到: $env_file"
     
     # 设置默认模型
-    if check_command clawdbot; then
-        local clawdbot_model=""
+    if check_command openclaw; then
+        local openclaw_model=""
         local use_custom_provider=false
         
         # 如果使用自定义 BASE_URL，需要配置自定义 provider
         if [ -n "$BASE_URL" ] && [ "$AI_PROVIDER" = "anthropic" ]; then
             use_custom_provider=true
-            configure_custom_provider "$AI_PROVIDER" "$AI_KEY" "$AI_MODEL" "$BASE_URL" "$clawdbot_json"
-            clawdbot_model="anthropic-custom/$AI_MODEL"
+            configure_custom_provider "$AI_PROVIDER" "$AI_KEY" "$AI_MODEL" "$BASE_URL" "$openclaw_json"
+            openclaw_model="anthropic-custom/$AI_MODEL"
         elif [ -n "$BASE_URL" ] && [ "$AI_PROVIDER" = "openai" ]; then
             use_custom_provider=true
-            configure_custom_provider "$AI_PROVIDER" "$AI_KEY" "$AI_MODEL" "$BASE_URL" "$clawdbot_json"
-            clawdbot_model="openai-custom/$AI_MODEL"
+            configure_custom_provider "$AI_PROVIDER" "$AI_KEY" "$AI_MODEL" "$BASE_URL" "$openclaw_json"
+            openclaw_model="openai-custom/$AI_MODEL"
         else
             case "$AI_PROVIDER" in
                 anthropic)
-                    clawdbot_model="anthropic/$AI_MODEL"
+                    openclaw_model="anthropic/$AI_MODEL"
                     ;;
                 openai|groq|mistral)
-                    clawdbot_model="openai/$AI_MODEL"
+                    openclaw_model="openai/$AI_MODEL"
                     ;;
                 openrouter)
-                    clawdbot_model="openrouter/$AI_MODEL"
+                    openclaw_model="openrouter/$AI_MODEL"
                     ;;
                 google)
-                    clawdbot_model="google/$AI_MODEL"
+                    openclaw_model="google/$AI_MODEL"
                     ;;
                 ollama)
-                    clawdbot_model="ollama/$AI_MODEL"
+                    openclaw_model="ollama/$AI_MODEL"
                     ;;
             esac
         fi
         
-        if [ -n "$clawdbot_model" ]; then
+        if [ -n "$openclaw_model" ]; then
             # 加载环境变量
             source "$env_file"
             
             # 设置默认模型（显示错误信息以便调试）
             # 添加 || true 防止 set -e 导致脚本退出
             local set_result
-            set_result=$(clawdbot models set "$clawdbot_model" 2>&1) || true
+            set_result=$(openclaw models set "$openclaw_model" 2>&1) || true
             local set_exit=$?
             
             if [ $set_exit -eq 0 ]; then
-                log_info "默认模型已设置为: $clawdbot_model"
+                log_info "默认模型已设置为: $openclaw_model"
             else
-                log_warn "模型设置可能失败: $clawdbot_model"
+                log_warn "模型设置可能失败: $openclaw_model"
                 echo -e "  ${GRAY}$set_result${NC}" | head -3
                 
                 # 尝试直接使用 config set
                 log_info "尝试使用 config set 设置模型..."
-                clawdbot config set models.default "$clawdbot_model" 2>/dev/null || true
+                openclaw config set models.default "$openclaw_model" 2>/dev/null || true
             fi
         fi
     fi
@@ -529,7 +535,7 @@ try {
         log_info "使用 node 配置自定义 Provider..."
         
         # 将变量写入临时文件，避免 shell 转义问题
-        local tmp_vars="/tmp/clawdbot_provider_vars_$$.json"
+        local tmp_vars="/tmp/openclaw_provider_vars_$$.json"
         cat > "$tmp_vars" << EOFVARS
 {
     "config_file": "$config_file",
@@ -609,7 +615,7 @@ console.log('Custom provider configured: ' + vars.provider_id);
         log_info "使用 python3 配置自定义 Provider..."
         
         # 将变量写入临时文件，避免 shell 转义问题
-        local tmp_vars="/tmp/clawdbot_provider_vars_$$.json"
+        local tmp_vars="/tmp/openclaw_provider_vars_$$.json"
         cat > "$tmp_vars" << EOFVARS
 {
     "config_file": "$config_file",
@@ -717,9 +723,9 @@ add_env_to_shell() {
     
     if [ -n "$shell_rc" ]; then
         # 检查是否已添加
-        if ! grep -q "source.*clawdbot/env" "$shell_rc" 2>/dev/null; then
+        if ! grep -q "source ~/.openclaw/env" "$shell_rc" 2>/dev/null; then
             echo "" >> "$shell_rc"
-            echo "# ClawdBot 环境变量" >> "$shell_rc"
+            echo "# OpenClaw 环境变量" >> "$shell_rc"
             echo "[ -f \"$env_file\" ] && source \"$env_file\"" >> "$shell_rc"
             log_info "环境变量已添加到: $shell_rc"
         fi
@@ -728,30 +734,30 @@ add_env_to_shell() {
 
 # ================================ 配置向导 ================================
 
-# create_default_config 已移除 - ClawdBot 使用 clawdbot.json 和环境变量
+# create_default_config 已移除 - OpenClaw 使用 openclaw.json 和环境变量
 
 run_onboard_wizard() {
     log_step "运行配置向导..."
     
     echo ""
     echo -e "${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${WHITE}           🧙 ClawdBot 核心配置向导${NC}"
+    echo -e "${WHITE}           🧙 OpenClaw 核心配置向导${NC}"
     echo -e "${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo ""
     
     # 检查是否已有配置
     local skip_ai_config=false
     local skip_identity_config=false
-    local env_file="$HOME/.clawdbot/env"
+    local env_file="$HOME/.openclaw/env"
     
     if [ -f "$env_file" ]; then
         echo -e "${YELLOW}检测到已有配置！${NC}"
         echo ""
         
         # 显示当前模型配置
-        if check_command clawdbot; then
-            echo -e "${CYAN}当前 ClawdBot 配置:${NC}"
-            clawdbot models status 2>/dev/null | head -10 || true
+        if check_command openclaw; then
+            echo -e "${CYAN}当前 OpenClaw 配置:${NC}"
+            openclaw models status 2>/dev/null | head -10 || true
             echo ""
         fi
         
@@ -764,7 +770,7 @@ run_onboard_wizard() {
                 # 从 env 文件读取配置进行测试
                 source "$env_file"
                 # 获取当前模型
-                AI_MODEL=$(clawdbot config get models.default 2>/dev/null | sed 's|.*/||')
+                AI_MODEL=$(openclaw config get models.default 2>/dev/null | sed 's|.*/||')
                 if [ -n "$ANTHROPIC_API_KEY" ]; then
                     AI_PROVIDER="anthropic"
                     AI_KEY="$ANTHROPIC_API_KEY"
@@ -794,8 +800,8 @@ run_onboard_wizard() {
     # AI 配置
     if [ "$skip_ai_config" = false ]; then
         setup_ai_provider
-        # 先配置 ClawdBot（设置环境变量和自定义 provider），然后再测试
-        configure_clawdbot_model
+        # 先配置 OpenClaw（设置环境变量和自定义 provider），然后再测试
+        configure_openclaw_model
         test_api_connection
     else
         # 即使跳过配置，也可选择测试连接
@@ -834,7 +840,7 @@ setup_ai_provider() {
     echo "  6) ⚡ Groq (超快推理)"
     echo "  7) 🌬️ Mistral AI"
     echo ""
-    echo -e "${GRAY}提示: Anthropic 支持自定义 API 地址（通过 clawdbot.json 配置自定义 Provider）${NC}"
+    echo -e "${GRAY}提示: Anthropic 支持自定义 API 地址（通过 openclaw.json 配置自定义 Provider）${NC}"
     echo ""
     echo -en "${YELLOW}请选择 AI 提供商 [1-7] (默认: 1): ${NC}"; read ai_choice < "$TTY_INPUT"
     ai_choice=${ai_choice:-1}
@@ -1037,31 +1043,31 @@ test_api_connection() {
     local retry_count=0
     
     # 确保环境变量已加载
-    local env_file="$HOME/.clawdbot/env"
+    local env_file="$HOME/.openclaw/env"
     [ -f "$env_file" ] && source "$env_file"
     
-    if ! check_command clawdbot; then
-        echo -e "${YELLOW}ClawdBot 未安装，跳过测试${NC}"
+    if ! check_command openclaw; then
+        echo -e "${YELLOW}OpenClaw 未安装，跳过测试${NC}"
         return 0
     fi
     
     # 显示当前模型配置
     echo -e "${CYAN}当前模型配置:${NC}"
-    clawdbot models status 2>&1 | grep -E "Default|Auth|effective" | head -5
+    openclaw models status 2>&1 | grep -E "Default|Auth|effective" | head -5
     echo ""
     
     while [ "$test_passed" = false ] && [ $retry_count -lt $max_retries ]; do
-        echo -e "${YELLOW}运行 clawdbot agent --local 测试...${NC}"
+        echo -e "${YELLOW}运行 openclaw agent --local 测试...${NC}"
         echo ""
         
-        # 使用 clawdbot agent --local 测试（添加超时）
+        # 使用 openclaw agent --local 测试（添加超时）
         local result
         local exit_code
         
         # 使用 timeout 命令（如果可用），否则直接运行
         # 注意：添加 || true 防止 set -e 导致脚本退出
         if command -v timeout &> /dev/null; then
-            result=$(timeout 30 clawdbot agent --local --to "+1234567890" --message "回复 OK" 2>&1) || true
+            result=$(timeout 30 openclaw agent --local --to "+1234567890" --message "回复 OK" 2>&1) || true
             exit_code=${PIPESTATUS[0]}
             # 如果 exit_code 为空，从 $? 获取（兼容不同 shell）
             [ -z "$exit_code" ] && exit_code=$?
@@ -1069,7 +1075,7 @@ test_api_connection() {
                 result="测试超时（30秒）"
             fi
         else
-            result=$(clawdbot agent --local --to "+1234567890" --message "回复 OK" 2>&1) || true
+            result=$(openclaw agent --local --to "+1234567890" --message "回复 OK" 2>&1) || true
             exit_code=$?
         fi
         
@@ -1084,7 +1090,7 @@ test_api_connection() {
         
         if [ $exit_code -eq 0 ] && ! echo "$result" | grep -qiE "error|failed|401|403|Unknown model|超时"; then
             test_passed=true
-            echo -e "${GREEN}✓ ClawdBot AI 测试成功！${NC}"
+            echo -e "${GREEN}✓ OpenClaw AI 测试成功！${NC}"
             echo ""
             # 显示 AI 响应（过滤掉空行）
             local ai_response=$(echo "$result" | grep -v "^$" | head -5)
@@ -1094,7 +1100,7 @@ test_api_connection() {
             fi
         else
             retry_count=$((retry_count + 1))
-            echo -e "${RED}✗ ClawdBot AI 测试失败 (退出码: $exit_code)${NC}"
+            echo -e "${RED}✗ OpenClaw AI 测试失败 (退出码: $exit_code)${NC}"
             echo ""
             echo -e "  ${RED}错误:${NC}"
             echo "$result" | head -5 | sed 's/^/    /'
@@ -1106,7 +1112,7 @@ test_api_connection() {
                 
                 # 提供修复建议
                 if echo "$result" | grep -q "Unknown model"; then
-                    echo -e "${YELLOW}提示: 模型不被识别，建议运行: clawdbot configure --section model${NC}"
+                    echo -e "${YELLOW}提示: 模型不被识别，建议运行: openclaw onboard --section model${NC}"
                 elif echo "$result" | grep -q "401\|Incorrect API key"; then
                     echo -e "${YELLOW}提示: API 配置可能不正确${NC}"
                 fi
@@ -1114,7 +1120,7 @@ test_api_connection() {
                 
                 if confirm "是否重新配置 AI Provider？" "y"; then
                     setup_ai_provider
-                    configure_clawdbot_model
+                    configure_openclaw_model
                 else
                     echo -e "${YELLOW}继续使用当前配置...${NC}"
                     test_passed=true  # 允许跳过
@@ -1127,8 +1133,8 @@ test_api_connection() {
         echo -e "${RED}API 连接测试失败${NC}"
         echo ""
         echo "建议运行以下命令手动配置:"
-        echo "  clawdbot configure --section model"
-        echo "  clawdbot doctor"
+        echo "  openclaw onboard --section model"
+        echo "  openclaw doctor"
         echo ""
         if confirm "是否仍然继续安装？" "y"; then
             log_warn "跳过连接测试，继续安装..."
@@ -1255,15 +1261,15 @@ setup_daemon() {
 }
 
 setup_systemd() {
-    cat > /tmp/clawdbot.service << EOF
+    cat > /tmp/openclaw.service << EOF
 [Unit]
-Description=ClawdBot AI Assistant
+Description=OpenClaw AI Assistant
 After=network.target
 
 [Service]
 Type=simple
 User=$USER
-ExecStart=$(which clawdbot) start --daemon
+ExecStart=$(which openclaw) start --daemon
 Restart=on-failure
 RestartSec=10
 
@@ -1271,9 +1277,9 @@ RestartSec=10
 WantedBy=multi-user.target
 EOF
 
-    sudo mv /tmp/clawdbot.service /etc/systemd/system/
+    sudo mv /tmp/openclaw.service /etc/systemd/system/
     sudo systemctl daemon-reload
-    sudo systemctl enable clawdbot
+    sudo systemctl enable openclaw
     
     log_info "Systemd 服务已配置"
 }
@@ -1281,16 +1287,16 @@ EOF
 setup_launchd() {
     mkdir -p "$HOME/Library/LaunchAgents"
     
-    cat > "$HOME/Library/LaunchAgents/com.clawdbot.agent.plist" << EOF
+    cat > "$HOME/Library/LaunchAgents/com.openclaw.agent.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.clawdbot.agent</string>
+    <string>com.openclaw.agent</string>
     <key>ProgramArguments</key>
     <array>
-        <string>$(which clawdbot)</string>
+        <string>$(which openclaw)</string>
         <string>start</string>
         <string>--daemon</string>
     </array>
@@ -1306,7 +1312,7 @@ setup_launchd() {
 </plist>
 EOF
 
-    launchctl load "$HOME/Library/LaunchAgents/com.clawdbot.agent.plist" 2>/dev/null || true
+    launchctl load "$HOME/Library/LaunchAgents/com.openclaw.agent.plist" 2>/dev/null || true
     
     log_info "LaunchAgent 已配置"
 }
@@ -1320,44 +1326,44 @@ print_success() {
     echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo ""
     echo -e "${WHITE}配置目录:${NC}"
-    echo "  ClawdBot 配置: ~/.clawdbot/"
-    echo "  环境变量配置: ~/.clawdbot/env"
+    echo "  OpenClaw 配置: ~/.openclaw/"
+    echo "  环境变量配置: ~/.openclaw/env"
     echo ""
     echo -e "${CYAN}常用命令:${NC}"
-    echo "  clawdbot gateway start   # 后台启动服务"
-    echo "  clawdbot gateway stop    # 停止服务"
-    echo "  clawdbot gateway status  # 查看状态"
-    echo "  clawdbot models status   # 查看模型配置"
-    echo "  clawdbot channels list   # 查看渠道列表"
-    echo "  clawdbot doctor          # 诊断问题"
+    echo "  openclaw gateway start   # 后台启动服务"
+    echo "  openclaw gateway stop    # 停止服务"
+    echo "  openclaw gateway status  # 查看状态"
+    echo "  openclaw models status   # 查看模型配置"
+    echo "  openclaw channels list   # 查看渠道列表"
+    echo "  openclaw doctor          # 诊断问题"
     echo ""
     echo -e "${PURPLE}📚 官方文档: https://clawd.bot/docs${NC}"
     echo -e "${PURPLE}💬 社区支持: https://github.com/$GITHUB_REPO/discussions${NC}"
     echo ""
 }
 
-# 启动 ClawdBot Gateway 服务
-start_clawdbot_service() {
+# 启动 OpenClaw Gateway 服务
+start_openclaw_service() {
     echo ""
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${WHITE}           🚀 启动 ClawdBot 服务${NC}"
+    echo -e "${WHITE}           🚀 启动 OpenClaw 服务${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo ""
     
     # 加载环境变量
-    local env_file="$HOME/.clawdbot/env"
+    local env_file="$HOME/.openclaw/env"
     if [ -f "$env_file" ]; then
         source "$env_file"
         log_info "已加载环境变量"
     fi
     
     # 检查是否已有服务在运行
-    if pgrep -f "clawdbot.*gateway" > /dev/null 2>&1; then
-        log_warn "ClawdBot Gateway 已在运行"
+    if pgrep -f "openclaw.*gateway" > /dev/null 2>&1; then
+        log_warn "OpenClaw Gateway 已在运行"
         echo ""
         if confirm "是否重启服务？" "y"; then
-            clawdbot gateway stop 2>/dev/null || true
-            pkill -f "clawdbot.*gateway" 2>/dev/null || true
+            openclaw gateway stop 2>/dev/null || true
+            pkill -f "openclaw.*gateway" 2>/dev/null || true
             sleep 2
         else
             return 0
@@ -1369,16 +1375,16 @@ start_clawdbot_service() {
     
     if command -v setsid &> /dev/null; then
         if [ -f "$env_file" ]; then
-            setsid bash -c "source $env_file && exec clawdbot gateway --port 18789" > /tmp/clawdbot-gateway.log 2>&1 &
+            setsid bash -c "source $env_file && exec openclaw gateway --port 18789" > /tmp/openclaw-gateway.log 2>&1 &
         else
-            setsid clawdbot gateway --port 18789 > /tmp/clawdbot-gateway.log 2>&1 &
+            setsid openclaw gateway --port 18789 > /tmp/openclaw-gateway.log 2>&1 &
         fi
     else
         # 备用方案：nohup + disown
         if [ -f "$env_file" ]; then
-            nohup bash -c "source $env_file && exec clawdbot gateway --port 18789" > /tmp/clawdbot-gateway.log 2>&1 &
+            nohup bash -c "source $env_file && exec openclaw gateway --port 18789" > /tmp/openclaw-gateway.log 2>&1 &
         else
-            nohup clawdbot gateway --port 18789 > /tmp/clawdbot-gateway.log 2>&1 &
+            nohup openclaw gateway --port 18789 > /tmp/openclaw-gateway.log 2>&1 &
         fi
         disown 2>/dev/null || true
     fi
@@ -1386,22 +1392,22 @@ start_clawdbot_service() {
     sleep 3
     
     # 检查启动状态
-    if pgrep -f "clawdbot.*gateway" > /dev/null 2>&1; then
+    if pgrep -f "openclaw.*gateway" > /dev/null 2>&1; then
         echo ""
         echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo -e "${GREEN}           ✓ ClawdBot Gateway 已启动！${NC}"
+        echo -e "${GREEN}           ✓ OpenClaw Gateway 已启动！${NC}"
         echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
         echo ""
-        echo -e "  ${CYAN}日志文件:${NC} /tmp/clawdbot-gateway.log"
-        echo -e "  ${CYAN}查看日志:${NC} tail -f /tmp/clawdbot-gateway.log"
-        echo -e "  ${CYAN}停止服务:${NC} clawdbot gateway stop"
+        echo -e "  ${CYAN}日志文件:${NC} /tmp/openclaw-gateway.log"
+        echo -e "  ${CYAN}查看日志:${NC} tail -f /tmp/openclaw-gateway.log"
+        echo -e "  ${CYAN}停止服务:${NC} openclaw gateway stop"
         echo ""
-        log_info "ClawdBot 现在可以接收消息了！"
+        log_info "OpenClaw 现在可以接收消息了！"
     else
         log_error "Gateway 启动失败"
         echo ""
-        echo -e "${YELLOW}请查看日志: tail -f /tmp/clawdbot-gateway.log${NC}"
-        echo -e "${YELLOW}或手动启动: source ~/.clawdbot/env && clawdbot gateway${NC}"
+        echo -e "${YELLOW}请查看日志: tail -f /tmp/openclaw-gateway.log${NC}"
+        echo -e "${YELLOW}或手动启动: source ~/.openclaw/env && openclaw gateway${NC}"
     fi
 }
 
@@ -1459,7 +1465,7 @@ run_config_menu() {
 main() {
     print_banner
     
-    echo -e "${YELLOW}⚠️  警告: ClawdBot 需要完全的计算机权限${NC}"
+    echo -e "${YELLOW}⚠️  警告: OpenClaw 需要完全的计算机权限${NC}"
     echo -e "${YELLOW}    不建议在主要工作电脑上安装，建议使用专用服务器或虚拟机${NC}"
     echo ""
     
@@ -1473,18 +1479,18 @@ main() {
     check_root
     install_dependencies
     create_directories
-    install_clawdbot
+    install_openclaw
     run_onboard_wizard
     setup_daemon
     print_success
     
     # 询问是否启动服务
-    if confirm "是否现在启动 ClawdBot 服务？" "y"; then
-        start_clawdbot_service
+    if confirm "是否现在启动 OpenClaw 服务？" "y"; then
+        start_openclaw_service
     else
         echo ""
         echo -e "${CYAN}稍后可以通过以下命令启动服务:${NC}"
-        echo "  source ~/.clawdbot/env && clawdbot gateway"
+        echo "  source ~/.openclaw/env && openclaw gateway"
         echo ""
     fi
     
@@ -1509,7 +1515,7 @@ main() {
     fi
     
     echo ""
-    echo -e "${GREEN}🦞 ClawdBot 安装完成！祝你使用愉快！${NC}"
+    echo -e "${GREEN}🦞 OpenClaw 安装完成！祝你使用愉快！${NC}"
     echo ""
 }
 


### PR DESCRIPTION
BREAKING CHANGE: 命令从 'clawdbot' 更改为 'openclaw'

主要变更:
- 所有命令: clawdbot → openclaw
- 配置目录: ~/.clawdbot → ~/.openclaw
- npm包: clawdbot@latest → openclaw@latest
- message命令改为子命令格式: message send|poll|...

新增命令支持:
- openclaw update (v2026.1.10+)
- openclaw status --all 完整状态报告
- openclaw message send --provider <provider>

更新文件:
- README.md: 更新所有命令说明和文档
- install.sh: 升级至 v1.1.0
- config-menu.sh: 更新所有函数和变量名
- docker-entrypoint.sh: 更新配置目录
- Dockerfile: 更新镜像和路径
- docker-compose.yml: 更新服务名和配置
- examples/: 更新示例配置路径

参考: https://github.com/openclaw/openclaw/releases/tag/v2026.1.24