### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/config-menu.sh
+++ b/config-menu.sh
@@ -2861,23 +2861,21 @@ config_minimax() {
     echo ""
     echo -e "${CYAN}选择模型:${NC}"
     echo ""
-    print_menu_item "1" "MiniMax-M2.7 (推荐，最新旗舰)" "⭐"
-    print_menu_item "2" "MiniMax-M2.7-highspeed (高速版)" "⚡"
-    print_menu_item "3" "MiniMax-M2.5" "🔹"
-    print_menu_item "4" "MiniMax-M2.5-highspeed" "🔹"
-    print_menu_item "5" "自定义模型名称" "✏️"
+    print_menu_item "1" "MiniMax-M3 (推荐，最新旗舰)" "⭐"
+    print_menu_item "2" "MiniMax-M2.7 (旧版稳定)" "🔹"
+    print_menu_item "3" "MiniMax-M2.7-highspeed (旧版高速)" "⚡"
+    print_menu_item "4" "自定义模型名称" "✏️"
     echo ""
 
-    read -p "$(echo -e "${YELLOW}请选择 [1-5] (默认: 1): ${NC}")" model_choice < "$TTY_INPUT"
+    read -p "$(echo -e "${YELLOW}请选择 [1-4] (默认: 1): ${NC}")" model_choice < "$TTY_INPUT"
     model_choice=${model_choice:-1}
 
     case $model_choice in
-        1) model="MiniMax-M2.7" ;;
-        2) model="MiniMax-M2.7-highspeed" ;;
-        3) model="MiniMax-M2.5" ;;
-        4) model="MiniMax-M2.5-highspeed" ;;
-        5) read -p "$(echo -e "${YELLOW}输入模型名称: ${NC}")" model < "$TTY_INPUT" ;;
-        *) model="MiniMax-M2.7" ;;
+        1) model="MiniMax-M3" ;;
+        2) model="MiniMax-M2.7" ;;
+        3) model="MiniMax-M2.7-highspeed" ;;
+        4) read -p "$(echo -e "${YELLOW}输入模型名称: ${NC}")" model < "$TTY_INPUT" ;;
+        *) model="MiniMax-M3" ;;
     esac
     
     # 保存到 OpenClaw 环境变量配置
@@ -5704,7 +5702,7 @@ ensure_openclaw_init() {
 # 为 MiniMax 写入官方兼容 provider 配置，避免旧版本出现 Unknown model
 ensure_minimax_provider_config() {
     local provider="$1"   # minimax|minimax-cn
-    local model="$2"      # MiniMax-M2.5 / MiniMax-M2.5-highspeed
+    local model="$2"      # MiniMax-M3 / MiniMax-M2.7 / MiniMax-M2.7-highspeed
     local config_file="$3"
     local base_url="https://api.minimax.io/anthropic"
     if [ "$provider" = "minimax-cn" ]; then
@@ -5729,11 +5727,12 @@ cfg.models.providers ||= {};
 const p = cfg.models.providers[provider] || {};
 const models = Array.isArray(p.models) ? p.models : [];
 const catalog = {
-  'MiniMax-M2.5': { name: 'MiniMax M2.5' },
-  'MiniMax-M2.5-highspeed': { name: 'MiniMax M2.5 Highspeed' },
+  'MiniMax-M3': { name: 'MiniMax M3' },
+  'MiniMax-M2.7': { name: 'MiniMax M2.7' },
+  'MiniMax-M2.7-highspeed': { name: 'MiniMax M2.7 Highspeed' },
 };
 const modelIds = new Set(models.map(m => m.id));
-for (const id of ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']) {
+for (const id of ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']) {
   if (!modelIds.has(id)) {
     models.push({
       id,
@@ -5778,11 +5777,12 @@ cfg["models"].setdefault("providers", {})
 p = cfg["models"]["providers"].get(provider, {})
 models = p.get("models", []) if isinstance(p.get("models"), list) else []
 catalog = {
-    "MiniMax-M2.5": "MiniMax M2.5",
-    "MiniMax-M2.5-highspeed": "MiniMax M2.5 Highspeed",
+    "MiniMax-M3": "MiniMax M3",
+    "MiniMax-M2.7": "MiniMax M2.7",
+    "MiniMax-M2.7-highspeed": "MiniMax M2.7 Highspeed",
 }
 existing = {m.get("id") for m in models if isinstance(m, dict)}
-for mid in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed"):
+for mid in ("MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
     if mid not in existing:
         models.append({
             "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": ["text"],

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -54,7 +54,7 @@ llm:
   # Mistral: mistral-large-latest / mistral-medium-latest / codestral-latest
   # xAI: grok-4-fast / grok-4 / grok-3-fast-latest / grok-2-vision-latest
   # 智谱 (zai): glm-4.7 / glm-4.6 / glm-4.6v / glm-4.5-flash
-  # MiniMax: MiniMax-M2.7 / MiniMax-M2.7-highspeed / MiniMax-M2.5 / MiniMax-M2.5-highspeed
+  # MiniMax: MiniMax-M3 / MiniMax-M2.7 / MiniMax-M2.7-highspeed
   # OpenCode: claude-sonnet-4-5 / gpt-5 / gemini-3-pro / glm-4.7-free
   # Ollama: llama3 / mistral / codellama 等
   # OpenAI Compatible: 根据你的服务支持的模型填写

--- a/install.sh
+++ b/install.sh
@@ -1352,7 +1352,7 @@ init_openclaw_config() {
 # 为 MiniMax 写入官方兼容 provider 配置，避免旧版本出现 Unknown model
 ensure_minimax_provider_config() {
     local provider="$1"   # minimax|minimax-cn
-    local model="$2"      # MiniMax-M2.5 / MiniMax-M2.5-highspeed
+    local model="$2"      # MiniMax-M3 / MiniMax-M2.7 / MiniMax-M2.7-highspeed
     local config_file="$3"
     local base_url="https://api.minimax.io/anthropic"
     if [ "$provider" = "minimax-cn" ]; then
@@ -1377,11 +1377,12 @@ cfg.models.providers ||= {};
 const p = cfg.models.providers[provider] || {};
 const models = Array.isArray(p.models) ? p.models : [];
 const catalog = {
-  'MiniMax-M2.5': { name: 'MiniMax M2.5' },
-  'MiniMax-M2.5-highspeed': { name: 'MiniMax M2.5 Highspeed' },
+  'MiniMax-M3': { name: 'MiniMax M3' },
+  'MiniMax-M2.7': { name: 'MiniMax M2.7' },
+  'MiniMax-M2.7-highspeed': { name: 'MiniMax M2.7 Highspeed' },
 };
 const modelIds = new Set(models.map(m => m.id));
-for (const id of ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']) {
+for (const id of ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']) {
   if (!modelIds.has(id)) {
     models.push({
       id,
@@ -1426,11 +1427,12 @@ cfg["models"].setdefault("providers", {})
 p = cfg["models"]["providers"].get(provider, {})
 models = p.get("models", []) if isinstance(p.get("models"), list) else []
 catalog = {
-    "MiniMax-M2.5": "MiniMax M2.5",
-    "MiniMax-M2.5-highspeed": "MiniMax M2.5 Highspeed",
+    "MiniMax-M3": "MiniMax M3",
+    "MiniMax-M2.7": "MiniMax M2.7",
+    "MiniMax-M2.7-highspeed": "MiniMax M2.7 Highspeed",
 }
 existing = {m.get("id") for m in models if isinstance(m, dict)}
-for mid in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed"):
+for mid in ("MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
     if mid not in existing:
         models.append({
             "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": ["text"],
@@ -2427,14 +2429,16 @@ setup_ai_provider() {
             read_secret_input "${YELLOW}输入 API Key: ${NC}" AI_KEY
             echo ""
             echo "选择模型:"
-            echo "  1) MiniMax-M2.5 (推荐，官方)"
-            echo "  2) MiniMax-M2.5-highspeed (高速)"
-            echo "  3) 自定义模型名称"
-            echo -en "${YELLOW}选择模型 [1-3] (默认: 1): ${NC}"; read model_choice < "$TTY_INPUT"
+            echo "  1) MiniMax-M3 (推荐，最新旗舰)"
+            echo "  2) MiniMax-M2.7 (旧版稳定)"
+            echo "  3) MiniMax-M2.7-highspeed (旧版高速)"
+            echo "  4) 自定义模型名称"
+            echo -en "${YELLOW}选择模型 [1-4] (默认: 1): ${NC}"; read model_choice < "$TTY_INPUT"
             case $model_choice in
-                2) AI_MODEL="MiniMax-M2.5-highspeed" ;;
-                3) echo -en "${YELLOW}输入模型名称: ${NC}"; read AI_MODEL < "$TTY_INPUT" ;;
-                *) AI_MODEL="MiniMax-M2.5" ;;
+                2) AI_MODEL="MiniMax-M2.7" ;;
+                3) AI_MODEL="MiniMax-M2.7-highspeed" ;;
+                4) echo -en "${YELLOW}输入模型名称: ${NC}"; read AI_MODEL < "$TTY_INPUT" ;;
+                *) AI_MODEL="MiniMax-M3" ;;
             esac
             ;;
         13)


### PR DESCRIPTION
## Summary

Upgrade the MiniMax provider default model from M2.5 to the latest **MiniMax-M3**, in line with MiniMax's currently published flagship. Keep M2.7 and M2.7-highspeed available as legacy options for users that prefer the previous generation; remove M2.5 and M2.5-highspeed from the menus and catalog.

## Changes

- **`install.sh`**
  - Interactive setup menu now lists: `MiniMax-M3 (推荐)` / `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` / 自定义
  - `ensure_minimax_provider_config` catalog (both Node and Python branches) registers `M3`, `M2.7`, `M2.7-highspeed` instead of the old M2.5 pair
- **`config-menu.sh`**
  - Same updates applied to `config_minimax` and `ensure_minimax_provider_config`
- **`examples/config.example.yaml`**
  - Comment line listing MiniMax models updated to the new lineup

## Why

MiniMax M3 是当前官方旗舰；继续把 M2.5 作为默认会让新用户拿到老一代效果，并在 OpenClaw 的 provider catalog 里残留过期 model id。M2.7 系列仍保留，做老用户的兼容退路。

## Test

- `bash -n install.sh` / `bash -n config-menu.sh` 通过
- 单独跑 `ensure_minimax_provider_config minimax MiniMax-M3 /tmp/out.json` (Node 和 Python 两条路径均验证)，输出 JSON 内 `models.providers.minimax.models` 三个 ID 齐全、`agents.defaults.models["minimax/MiniMax-M3"].alias = "Minimax"`
- 菜单选项 1 → AI_MODEL=MiniMax-M3 正确，国际/国内 base URL 未变