### PR TITLE
Refresh MiniMax model parameters

### DIFF
--- a/config-menu.sh
+++ b/config-menu.sh
@@ -2861,8 +2861,8 @@ config_minimax() {
     echo ""
     echo -e "${CYAN}选择模型:${NC}"
     echo ""
-    print_menu_item "1" "MiniMax-M2.7 (推荐，最新旗舰)" "⭐"
-    print_menu_item "2" "MiniMax-M2.7-highspeed (高速版)" "⚡"
+    print_menu_item "1" "MiniMax-M3 (推荐，最新旗舰)" "⭐"
+    print_menu_item "2" "MiniMax-M2.7" "🔹"
     print_menu_item "3" "MiniMax-M2.5" "🔹"
     print_menu_item "4" "MiniMax-M2.5-highspeed" "🔹"
     print_menu_item "5" "自定义模型名称" "✏️"
@@ -2872,12 +2872,12 @@ config_minimax() {
     model_choice=${model_choice:-1}
 
     case $model_choice in
-        1) model="MiniMax-M2.7" ;;
-        2) model="MiniMax-M2.7-highspeed" ;;
+        1) model="MiniMax-M3" ;;
+        2) model="MiniMax-M2.7" ;;
         3) model="MiniMax-M2.5" ;;
         4) model="MiniMax-M2.5-highspeed" ;;
         5) read -p "$(echo -e "${YELLOW}输入模型名称: ${NC}")" model < "$TTY_INPUT" ;;
-        *) model="MiniMax-M2.7" ;;
+        *) model="MiniMax-M3" ;;
     esac
     
     # 保存到 OpenClaw 环境变量配置
@@ -5729,19 +5729,19 @@ cfg.models.providers ||= {};
 const p = cfg.models.providers[provider] || {};
 const models = Array.isArray(p.models) ? p.models : [];
 const catalog = {
-  'MiniMax-M2.5': { name: 'MiniMax M2.5' },
-  'MiniMax-M2.5-highspeed': { name: 'MiniMax M2.5 Highspeed' },
+  'MiniMax-M3': { name: 'MiniMax M3' },
+  'MiniMax-M2.7': { name: 'MiniMax M2.7' },
 };
 const modelIds = new Set(models.map(m => m.id));
-for (const id of ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']) {
+for (const id of ['MiniMax-M3', 'MiniMax-M2.7']) {
   if (!modelIds.has(id)) {
     models.push({
       id,
       name: (catalog[id] && catalog[id].name) || id,
       reasoning: true,
-      input: ['text'],
-      cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-      contextWindow: 200000,
+      input: id === 'MiniMax-M3' ? ['text', 'image', 'video'] : ['text'],
+      cost: id === 'MiniMax-M3' ? { input: 0.6, output: 2.4, cacheRead: 0.12 } : { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+      contextWindow: id === 'MiniMax-M3' ? 1000000 : 204800,
       maxTokens: 8192
     });
   }
@@ -5778,16 +5778,16 @@ cfg["models"].setdefault("providers", {})
 p = cfg["models"]["providers"].get(provider, {})
 models = p.get("models", []) if isinstance(p.get("models"), list) else []
 catalog = {
-    "MiniMax-M2.5": "MiniMax M2.5",
-    "MiniMax-M2.5-highspeed": "MiniMax M2.5 Highspeed",
+    "MiniMax-M3": "MiniMax M3",
+    "MiniMax-M2.7": "MiniMax M2.7",
 }
 existing = {m.get("id") for m in models if isinstance(m, dict)}
-for mid in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed"):
+for mid in ("MiniMax-M3", "MiniMax-M2.7"):
     if mid not in existing:
         models.append({
-            "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": ["text"],
-            "cost": {"input": 0.3, "output": 1.2, "cacheRead": 0.03, "cacheWrite": 0.12},
-            "contextWindow": 200000, "maxTokens": 8192
+            "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": (["text", "image", "video"] if mid == "MiniMax-M3" else ["text"]),
+            "cost": ({"input": 0.6, "output": 2.4, "cacheRead": 0.12} if mid == "MiniMax-M3" else {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375}),
+            "contextWindow": (1000000 if mid == "MiniMax-M3" else 204800), "maxTokens": 8192
         })
 cfg["models"]["providers"][provider] = {
     **(p if isinstance(p, dict) else {}),

--- a/config-menu.sh
+++ b/config-menu.sh
@@ -2863,20 +2863,16 @@ config_minimax() {
     echo ""
     print_menu_item "1" "MiniMax-M3 (推荐，最新旗舰)" "⭐"
     print_menu_item "2" "MiniMax-M2.7" "🔹"
-    print_menu_item "3" "MiniMax-M2.5" "🔹"
-    print_menu_item "4" "MiniMax-M2.5-highspeed" "🔹"
-    print_menu_item "5" "自定义模型名称" "✏️"
+    print_menu_item "3" "自定义模型名称" "✏️"
     echo ""
 
-    read -p "$(echo -e "${YELLOW}请选择 [1-5] (默认: 1): ${NC}")" model_choice < "$TTY_INPUT"
+    read -p "$(echo -e "${YELLOW}请选择 [1-3] (默认: 1): ${NC}")" model_choice < "$TTY_INPUT"
     model_choice=${model_choice:-1}
 
     case $model_choice in
         1) model="MiniMax-M3" ;;
         2) model="MiniMax-M2.7" ;;
-        3) model="MiniMax-M2.5" ;;
-        4) model="MiniMax-M2.5-highspeed" ;;
-        5) read -p "$(echo -e "${YELLOW}输入模型名称: ${NC}")" model < "$TTY_INPUT" ;;
+        3) read -p "$(echo -e "${YELLOW}输入模型名称: ${NC}")" model < "$TTY_INPUT" ;;
         *) model="MiniMax-M3" ;;
     esac
     
@@ -5704,7 +5700,7 @@ ensure_openclaw_init() {
 # 为 MiniMax 写入官方兼容 provider 配置，避免旧版本出现 Unknown model
 ensure_minimax_provider_config() {
     local provider="$1"   # minimax|minimax-cn
-    local model="$2"      # MiniMax-M2.5 / MiniMax-M2.5-highspeed
+    local model="$2"      # MiniMax-M3 / MiniMax-M2.7
     local config_file="$3"
     local base_url="https://api.minimax.io/anthropic"
     if [ "$provider" = "minimax-cn" ]; then
@@ -5729,22 +5725,14 @@ cfg.models.providers ||= {};
 const p = cfg.models.providers[provider] || {};
 const models = Array.isArray(p.models) ? p.models : [];
 const catalog = {
-  'MiniMax-M3': { name: 'MiniMax M3' },
-  'MiniMax-M2.7': { name: 'MiniMax M2.7' },
+  'MiniMax-M3': { name: 'MiniMax M3', reasoning: true, input: ['text', 'image', 'video'], cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null }, contextWindow: 1000000, maxTokens: 8192 },
+  'MiniMax-M2.7': { name: 'MiniMax M2.7', reasoning: true, input: ['text'], cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }, contextWindow: 204800, maxTokens: 8192 },
 };
-const modelIds = new Set(models.map(m => m.id));
 for (const id of ['MiniMax-M3', 'MiniMax-M2.7']) {
-  if (!modelIds.has(id)) {
-    models.push({
-      id,
-      name: (catalog[id] && catalog[id].name) || id,
-      reasoning: true,
-      input: id === 'MiniMax-M3' ? ['text', 'image', 'video'] : ['text'],
-      cost: id === 'MiniMax-M3' ? { input: 0.6, output: 2.4, cacheRead: 0.12 } : { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
-      contextWindow: id === 'MiniMax-M3' ? 1000000 : 204800,
-      maxTokens: 8192
-    });
-  }
+  const existing = models.find(m => m && m.id === id);
+  const refreshed = { id, ...catalog[id] };
+  if (existing) Object.assign(existing, refreshed);
+  else models.push(refreshed);
 }
 cfg.models.providers[provider] = {
   ...p,
@@ -5778,17 +5766,16 @@ cfg["models"].setdefault("providers", {})
 p = cfg["models"]["providers"].get(provider, {})
 models = p.get("models", []) if isinstance(p.get("models"), list) else []
 catalog = {
-    "MiniMax-M3": "MiniMax M3",
-    "MiniMax-M2.7": "MiniMax M2.7",
+    "MiniMax-M3": {"name": "MiniMax M3", "reasoning": True, "input": ["text", "image", "video"], "cost": {"input": 0.6, "output": 2.4, "cacheRead": 0.12, "cacheWrite": None}, "contextWindow": 1000000, "maxTokens": 8192},
+    "MiniMax-M2.7": {"name": "MiniMax M2.7", "reasoning": True, "input": ["text"], "cost": {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375}, "contextWindow": 204800, "maxTokens": 8192},
 }
-existing = {m.get("id") for m in models if isinstance(m, dict)}
 for mid in ("MiniMax-M3", "MiniMax-M2.7"):
-    if mid not in existing:
-        models.append({
-            "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": (["text", "image", "video"] if mid == "MiniMax-M3" else ["text"]),
-            "cost": ({"input": 0.6, "output": 2.4, "cacheRead": 0.12} if mid == "MiniMax-M3" else {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375}),
-            "contextWindow": (1000000 if mid == "MiniMax-M3" else 204800), "maxTokens": 8192
-        })
+    refreshed = {"id": mid, **catalog[mid]}
+    existing = next((item for item in models if isinstance(item, dict) and item.get("id") == mid), None)
+    if existing is not None:
+        existing.update(refreshed)
+    else:
+        models.append(refreshed)
 cfg["models"]["providers"][provider] = {
     **(p if isinstance(p, dict) else {}),
     "baseUrl": base_url,

--- a/config-menu.sh
+++ b/config-menu.sh
@@ -2861,7 +2861,7 @@ config_minimax() {
     echo ""
     echo -e "${CYAN}选择模型:${NC}"
     echo ""
-    print_menu_item "1" "MiniMax-M3 (推荐，最新旗舰)" "⭐"
+    print_menu_item "1" "MiniMax-M3 (Recommended, latest flagship)" "⭐"
     print_menu_item "2" "MiniMax-M2.7" "🔹"
     print_menu_item "3" "Custom model name" "✏️"
     echo ""

--- a/config-menu.sh
+++ b/config-menu.sh
@@ -2863,16 +2863,16 @@ config_minimax() {
     echo ""
     print_menu_item "1" "MiniMax-M3 (推荐，最新旗舰)" "⭐"
     print_menu_item "2" "MiniMax-M2.7" "🔹"
-    print_menu_item "3" "自定义模型名称" "✏️"
+    print_menu_item "3" "Custom model name" "✏️"
     echo ""
 
-    read -p "$(echo -e "${YELLOW}请选择 [1-3] (默认: 1): ${NC}")" model_choice < "$TTY_INPUT"
+    read -p "$(echo -e "${YELLOW}Select [1-3] (default: 1): ${NC}")" model_choice < "$TTY_INPUT"
     model_choice=${model_choice:-1}
 
     case $model_choice in
         1) model="MiniMax-M3" ;;
         2) model="MiniMax-M2.7" ;;
-        3) read -p "$(echo -e "${YELLOW}输入模型名称: ${NC}")" model < "$TTY_INPUT" ;;
+        3) read -p "$(echo -e "${YELLOW}Enter model name: ${NC}")" model < "$TTY_INPUT" ;;
         *) model="MiniMax-M3" ;;
     esac
     

--- a/install.sh
+++ b/install.sh
@@ -1352,7 +1352,7 @@ init_openclaw_config() {
 # 为 MiniMax 写入官方兼容 provider 配置，避免旧版本出现 Unknown model
 ensure_minimax_provider_config() {
     local provider="$1"   # minimax|minimax-cn
-    local model="$2"      # MiniMax-M2.5 / MiniMax-M2.5-highspeed
+    local model="$2"      # MiniMax-M3 / MiniMax-M2.7
     local config_file="$3"
     local base_url="https://api.minimax.io/anthropic"
     if [ "$provider" = "minimax-cn" ]; then
@@ -1377,22 +1377,14 @@ cfg.models.providers ||= {};
 const p = cfg.models.providers[provider] || {};
 const models = Array.isArray(p.models) ? p.models : [];
 const catalog = {
-  'MiniMax-M3': { name: 'MiniMax M3' },
-  'MiniMax-M2.7': { name: 'MiniMax M2.7' },
+  'MiniMax-M3': { name: 'MiniMax M3', reasoning: true, input: ['text', 'image', 'video'], cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null }, contextWindow: 1000000, maxTokens: 8192 },
+  'MiniMax-M2.7': { name: 'MiniMax M2.7', reasoning: true, input: ['text'], cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }, contextWindow: 204800, maxTokens: 8192 },
 };
-const modelIds = new Set(models.map(m => m.id));
 for (const id of ['MiniMax-M3', 'MiniMax-M2.7']) {
-  if (!modelIds.has(id)) {
-    models.push({
-      id,
-      name: (catalog[id] && catalog[id].name) || id,
-      reasoning: true,
-      input: id === 'MiniMax-M3' ? ['text', 'image', 'video'] : ['text'],
-      cost: id === 'MiniMax-M3' ? { input: 0.6, output: 2.4, cacheRead: 0.12 } : { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
-      contextWindow: id === 'MiniMax-M3' ? 1000000 : 204800,
-      maxTokens: 8192
-    });
-  }
+  const existing = models.find(m => m && m.id === id);
+  const refreshed = { id, ...catalog[id] };
+  if (existing) Object.assign(existing, refreshed);
+  else models.push(refreshed);
 }
 cfg.models.providers[provider] = {
   ...p,
@@ -1426,17 +1418,16 @@ cfg["models"].setdefault("providers", {})
 p = cfg["models"]["providers"].get(provider, {})
 models = p.get("models", []) if isinstance(p.get("models"), list) else []
 catalog = {
-    "MiniMax-M3": "MiniMax M3",
-    "MiniMax-M2.7": "MiniMax M2.7",
+    "MiniMax-M3": {"name": "MiniMax M3", "reasoning": True, "input": ["text", "image", "video"], "cost": {"input": 0.6, "output": 2.4, "cacheRead": 0.12, "cacheWrite": None}, "contextWindow": 1000000, "maxTokens": 8192},
+    "MiniMax-M2.7": {"name": "MiniMax M2.7", "reasoning": True, "input": ["text"], "cost": {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375}, "contextWindow": 204800, "maxTokens": 8192},
 }
-existing = {m.get("id") for m in models if isinstance(m, dict)}
 for mid in ("MiniMax-M3", "MiniMax-M2.7"):
-    if mid not in existing:
-        models.append({
-            "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": (["text", "image", "video"] if mid == "MiniMax-M3" else ["text"]),
-            "cost": ({"input": 0.6, "output": 2.4, "cacheRead": 0.12} if mid == "MiniMax-M3" else {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375}),
-            "contextWindow": (1000000 if mid == "MiniMax-M3" else 204800), "maxTokens": 8192
-        })
+    refreshed = {"id": mid, **catalog[mid]}
+    existing = next((item for item in models if isinstance(item, dict) and item.get("id") == mid), None)
+    if existing is not None:
+        existing.update(refreshed)
+    else:
+        models.append(refreshed)
 cfg["models"]["providers"][provider] = {
     **(p if isinstance(p, dict) else {}),
     "baseUrl": base_url,

--- a/install.sh
+++ b/install.sh
@@ -1377,19 +1377,19 @@ cfg.models.providers ||= {};
 const p = cfg.models.providers[provider] || {};
 const models = Array.isArray(p.models) ? p.models : [];
 const catalog = {
-  'MiniMax-M2.5': { name: 'MiniMax M2.5' },
-  'MiniMax-M2.5-highspeed': { name: 'MiniMax M2.5 Highspeed' },
+  'MiniMax-M3': { name: 'MiniMax M3' },
+  'MiniMax-M2.7': { name: 'MiniMax M2.7' },
 };
 const modelIds = new Set(models.map(m => m.id));
-for (const id of ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']) {
+for (const id of ['MiniMax-M3', 'MiniMax-M2.7']) {
   if (!modelIds.has(id)) {
     models.push({
       id,
       name: (catalog[id] && catalog[id].name) || id,
       reasoning: true,
-      input: ['text'],
-      cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-      contextWindow: 200000,
+      input: id === 'MiniMax-M3' ? ['text', 'image', 'video'] : ['text'],
+      cost: id === 'MiniMax-M3' ? { input: 0.6, output: 2.4, cacheRead: 0.12 } : { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+      contextWindow: id === 'MiniMax-M3' ? 1000000 : 204800,
       maxTokens: 8192
     });
   }
@@ -1426,16 +1426,16 @@ cfg["models"].setdefault("providers", {})
 p = cfg["models"]["providers"].get(provider, {})
 models = p.get("models", []) if isinstance(p.get("models"), list) else []
 catalog = {
-    "MiniMax-M2.5": "MiniMax M2.5",
-    "MiniMax-M2.5-highspeed": "MiniMax M2.5 Highspeed",
+    "MiniMax-M3": "MiniMax M3",
+    "MiniMax-M2.7": "MiniMax M2.7",
 }
 existing = {m.get("id") for m in models if isinstance(m, dict)}
-for mid in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed"):
+for mid in ("MiniMax-M3", "MiniMax-M2.7"):
     if mid not in existing:
         models.append({
-            "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": ["text"],
-            "cost": {"input": 0.3, "output": 1.2, "cacheRead": 0.03, "cacheWrite": 0.12},
-            "contextWindow": 200000, "maxTokens": 8192
+            "id": mid, "name": catalog.get(mid, mid), "reasoning": True, "input": (["text", "image", "video"] if mid == "MiniMax-M3" else ["text"]),
+            "cost": ({"input": 0.6, "output": 2.4, "cacheRead": 0.12} if mid == "MiniMax-M3" else {"input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375}),
+            "contextWindow": (1000000 if mid == "MiniMax-M3" else 204800), "maxTokens": 8192
         })
 cfg["models"]["providers"][provider] = {
     **(p if isinstance(p, dict) else {}),
@@ -2427,14 +2427,14 @@ setup_ai_provider() {
             read_secret_input "${YELLOW}输入 API Key: ${NC}" AI_KEY
             echo ""
             echo "选择模型:"
-            echo "  1) MiniMax-M2.5 (推荐，官方)"
-            echo "  2) MiniMax-M2.5-highspeed (高速)"
+            echo "  1) MiniMax-M3 (推荐，最新旗舰)"
+            echo "  2) MiniMax-M2.7"
             echo "  3) 自定义模型名称"
             echo -en "${YELLOW}选择模型 [1-3] (默认: 1): ${NC}"; read model_choice < "$TTY_INPUT"
             case $model_choice in
-                2) AI_MODEL="MiniMax-M2.5-highspeed" ;;
+                2) AI_MODEL="MiniMax-M2.7" ;;
                 3) echo -en "${YELLOW}输入模型名称: ${NC}"; read AI_MODEL < "$TTY_INPUT" ;;
-                *) AI_MODEL="MiniMax-M2.5" ;;
+                *) AI_MODEL="MiniMax-M3" ;;
             esac
             ;;
         13)

--- a/install.sh
+++ b/install.sh
@@ -2418,7 +2418,7 @@ setup_ai_provider() {
             read_secret_input "${YELLOW}输入 API Key: ${NC}" AI_KEY
             echo ""
             echo "选择模型:"
-            echo "  1) MiniMax-M3 (推荐，最新旗舰)"
+            echo "  1) MiniMax-M3 (Recommended, latest flagship)"
             echo "  2) MiniMax-M2.7"
             echo "  3) 自定义模型名称"
             echo -en "${YELLOW}选择模型 [1-3] (默认: 1): ${NC}"; read model_choice < "$TTY_INPUT"


### PR DESCRIPTION
Reason: Refresh MiniMax model parameters and endpoints to match the current target configuration.

Updates the MiniMax provider registry with the M3 and M2.7 model metadata, including context windows, pricing, and input modalities. The existing regional Anthropic endpoints remain aligned for global and China configurations, and both interactive setup paths now offer the current target models.

Checks:
- `bash -n install.sh`
- `bash -n config-menu.sh`
- `git diff --check`
